### PR TITLE
Add PSARC import functionality to InitState.fs

### DIFF
--- a/samples/DLCBuilder.Domain/InitState.fs
+++ b/samples/DLCBuilder.Domain/InitState.fs
@@ -29,14 +29,22 @@ let init localizer albumArtLoader databaseConnector exitHandler args =
                     ErrorOccurred)
             |> Option.toList
 
+        let importPsarc =
+            args
+            |> Array.tryFind (String.endsWith ".psarc")
+            |> Option.map (fun path ->
+                Cmd.ofMsg (path |> FolderTarget.PsarcImportTarget |> Dialog.FolderTarget |> ShowDialog))
+            |> Option.toList
+
         Cmd.batch [
-            Cmd.OfTask.perform Configuration.load localizer (fun config -> SetConfiguration(config, loadProject.IsEmpty, wasAbnormalExit))
+            Cmd.OfTask.perform Configuration.load localizer (fun config -> SetConfiguration(config, loadProject.IsEmpty && importPsarc.IsEmpty, wasAbnormalExit))
             Cmd.OfTask.perform RecentFilesList.load () SetRecentFiles
 #if !DEBUG
             Cmd.OfTask.perform OnlineUpdate.checkForUpdates () SetAvailableUpdate
 #endif
             Cmd.OfTask.perform ToneGear.loadRepository () SetToneRepository
             yield! loadProject
+            yield! importPsarc
         ]
 
     { Project = DLCProject.Empty


### PR DESCRIPTION
I'm working on a project that needs to open PSARC files directly in DLC builder.

Currently, only .rs2dlc project files are handled from CLI, this small change adds support for .psarc, triggering the existing Import PSARC flow (same as File -> Import PSARC File)