### PR TITLE
expose SongVolume and PreviewVolume in Manifest Attributes

### DIFF
--- a/samples/DLCBuilder.Domain/InitState.fs
+++ b/samples/DLCBuilder.Domain/InitState.fs
@@ -29,14 +29,22 @@ let init localizer albumArtLoader databaseConnector exitHandler args =
                     ErrorOccurred)
             |> Option.toList
 
+        let importPsarc =
+            args
+            |> Array.tryFind (String.endsWith ".psarc")
+            |> Option.map (fun path ->
+                Cmd.ofMsg (path |> FolderTarget.PsarcImportTarget |> Dialog.FolderTarget |> ShowDialog))
+            |> Option.toList
+
         Cmd.batch [
-            Cmd.OfTask.perform Configuration.load localizer (fun config -> SetConfiguration(config, loadProject.IsEmpty, wasAbnormalExit))
+            Cmd.OfTask.perform Configuration.load localizer (fun config -> SetConfiguration(config, loadProject.IsEmpty && importPsarc.IsEmpty, wasAbnormalExit))
             Cmd.OfTask.perform RecentFilesList.load () SetRecentFiles
 #if !DEBUG
             Cmd.OfTask.perform OnlineUpdate.checkForUpdates () SetAvailableUpdate
 #endif
             Cmd.OfTask.perform ToneGear.loadRepository () SetToneRepository
             yield! loadProject
+            yield! importPsarc
         ]
 
     { Project = DLCProject.Empty

--- a/src/Rocksmith2014.Common/Manifest/Attributes.fs
+++ b/src/Rocksmith2014.Common/Manifest/Attributes.fs
@@ -91,6 +91,8 @@ type Attributes() =
 
     member val PreviewBankPath: string = null with get, set
 
+    member val PreviewVolume: Nullable<float32> = Nullable() with get, set
+
     // Always zero
     member val RelativeDifficulty: Nullable<int> = Nullable() with get, set
 
@@ -137,6 +139,8 @@ type Attributes() =
     member val SongOffset: Nullable<float32> = Nullable() with get, set
 
     member val SongPartition: Nullable<int> = Nullable() with get, set
+
+    member val SongVolume: Nullable<float32> = Nullable() with get, set
 
     member val SongXml: string = null with get, set
 


### PR DESCRIPTION
Rocksmith manifests include SongVolume and PreviewVolume, but Attributes.fs currently omits them.

I'm working on a CFSM2 that needs to open PSARC files directly in DLC builder.

Currently, only .rs2dlc project files are handled from CLI, this small change adds support for .psarc, triggering the existing Import PSARC flow (same as File -> Import PSARC File)